### PR TITLE
Single sourcing pkg version & setup fix

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,3 @@
 [metadata]
 description-file = README.md
+version = attr: flask_voluptuous.__version__

--- a/setup.py
+++ b/setup.py
@@ -1,16 +1,12 @@
 from distutils.core import setup
 
-from flask_voluptuous import __version__
-
 setup(
   name = 'flask_voluptuous',
   py_modules = ['flask_voluptuous'], # this must be the same as the name above
-  version = __version__,
   description = 'A simple flask extension for data validation with Voluptuous',
   author = 'Ludovico O. Russo',
   author_email = 'ludus.russo@gmail.com',
   url = 'https://github.com/ludusrusso/flask_voluptuous/tree/develop', # use the URL to the github repo
-  download_url = 'https://github.com/ludusrusso/flask_voluptuous/tree/develop/archive/{0}.tar.gz'.format(__version__), # I'll explain this in a second
   keywords = ['voluptous', 'flask', 'validation'], # arbitrary keywords
   classifiers = [],
   install_requires=[


### PR DESCRIPTION
Based on info from
https://packaging.python.org/guides/single-sourcing-package-version/
and also notes from
https://github.com/pypa/setuptools_scm/issues/95
I think this should fix the installation dep. missing problem fine, while keeping single source of pkg version (in the module).